### PR TITLE
cortex-a53: Unbreak the build

### DIFF
--- a/libc/arch-arm/cortex-a53/cortex-a53.mk
+++ b/libc/arch-arm/cortex-a53/cortex-a53.mk
@@ -13,3 +13,6 @@ libc_bionic_src_files_arm += \
     arch-arm/cortex-a15/bionic/strlen.S \
     arch-arm/cortex-a15/bionic/stpcpy.S \
     arch-arm/krait/bionic/memmove.S
+    
+libc_bionic_src_files_arm += \
+    arch-arm/bionic/memchr.v7a.S


### PR DESCRIPTION
- Add missing memchr compilation call.
